### PR TITLE
Adopt wheezy fixes (several CVEs and few bugs)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,28 @@
+libxml2 (2.8.0+dfsg1-7maemo0+0cssu2) unstable; urgency=high
+
+  * Fix cve-2013-0338 and cve-2013-0339: large memory consuption issues when
+    performing string substition during entity expansion (closes: #702260).
+  * Fix cve-2013-2877: out-of-bounds read when handling documents that end
+    abruptly.
+  * 0007-Fix-pthread-memory-corruption.patch: patch stolen from the 
+    upstream repository. Fix memory corruption when re-using the libxml2 
+    from threaded applications (Closes: #742258).
+  * 0008-Fix-a-thread-portability-problem.patch: Fix buggy patch 0007
+    (Closes: #765770)
+  * debian/patches/cve-2014-0191.patch: libxml2 could be made to consume
+    resources if it processed a specially crafted file.
+    (Closes: #747309, #762864, CVE-2014-0191)
+  * Add patch for CVE-2014-3660 (Closes: #765722)
+
+ -- Ludek Finstrle <luf@seznam.cz>  Thu,  9 Feb 2016 01:38:47 +0100
+
 libxml2 (2.8.0+dfsg1-7maemo0+0cssu1) unstable; urgency=low
 
   * Resync from upstream (Fixes several mem leaks and CVEs)
   * Downgrade debhelper version requirement
   * Use target's python for all things python
 
- -- Ludek Finstrle <luf@pzkagis.cz>  Thu, 10 Jan 2013 13:52:21 +0100
+ -- Ludek Finstrle <luf@seznam.cz>  Thu, 10 Jan 2013 13:52:21 +0100
 
 libxml2 (2.8.0+dfsg1-7) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: libxml2
 Priority: optional
 Section: libs
-Maintainer: Ludek Finstrle <luf@pzkagis.cz>
+Maintainer: Ludek Finstrle <luf@seznam.cz>
 XSBC-Original-Maintainer: Debian XML/SGML Group <debian-xml-sgml-pkgs@lists.alioth.debian.org>
 Standards-Version: 3.7.3.0
 Build-Depends: debhelper (>= 5.0.42), zlib1g-dev (>= 1:1.2.7) | libz-dev,

--- a/debian/patches/0007-Fix-pthread-memory-corruption.patch
+++ b/debian/patches/0007-Fix-pthread-memory-corruption.patch
@@ -1,0 +1,32 @@
+From 7a2215dbcd4882e45f618c5f78f8d975b7c47ed3 Mon Sep 17 00:00:00 2001
+From: Daniel Veillard <veillard@redhat.com>
+Date: Tue, 4 Sep 2012 12:05:17 +0800
+Subject: Fix reuse of xmlInitParser
+
+While xmlCleanupParser() should not be used unless complete control
+is insured over the programe making sure libxml2 is not in use anywhere
+It should still be usable, and allow a sequence of
+    xmlInitParser();
+    xmlCleanupParser();
+calls if needed, the problem is that the thread key wasn't reallocated
+on subsequent xmlinitParser() calls leading to corruption of pthread
+keys used by the program.
+
+* threads.c: make sure xmlCleanupParser() reset the pthread_once()
+             global variable driving thread key allocation.
+
+diff --git a/threads.c b/threads.c
+index 6d25565..f206149 100644
+--- a/threads.c
++++ b/threads.c
+@@ -915,6 +915,7 @@ xmlCleanupThreads(void)
+ #ifdef HAVE_PTHREAD_H
+     if ((libxml_is_threaded)  && (pthread_key_delete != NULL))
+         pthread_key_delete(globalkey);
++    once_control = PTHREAD_ONCE_INIT;
+ #elif defined(HAVE_WIN32_THREADS) && !defined(HAVE_COMPILER_TLS) && (!defined(LIBXML_STATIC) || defined(LIBXML_STATIC_FOR_DLL))
+     if (globalkey != TLS_OUT_OF_INDEXES) {
+         xmlGlobalStateCleanupHelperParams *p;
+-- 
+cgit v0.10.1
+

--- a/debian/patches/0008-Fix-a-thread-portability-problem.patch
+++ b/debian/patches/0008-Fix-a-thread-portability-problem.patch
@@ -1,0 +1,33 @@
+From: Friedrich Haubensak <hsk@fli-leibniz.de>
+Date: Wed, 12 Sep 2012 17:34:53 +0200
+Subject: Fix a thread portability problem
+
+cannot compile libxml2-2.9.0 using studio 12.1 compiler on solaris 10
+
+I.M.O. structure initializer (as PTHREAD_ONCE_INIT) cannot be used in
+a structure assignment anyway
+---
+ threads.c |    3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/threads.c b/threads.c
+index 50581f1..54f5d9e 100644
+--- a/threads.c
++++ b/threads.c
+@@ -146,6 +146,7 @@ struct _xmlRMutex {
+ static pthread_key_t globalkey;
+ static pthread_t mainthread;
+ static pthread_once_t once_control = PTHREAD_ONCE_INIT;
++static pthread_once_t once_control_init = PTHREAD_ONCE_INIT;
+ static pthread_mutex_t global_init_lock = PTHREAD_MUTEX_INITIALIZER;
+ #elif defined HAVE_WIN32_THREADS
+ #if defined(HAVE_COMPILER_TLS)
+@@ -915,7 +916,7 @@ xmlCleanupThreads(void)
+ #ifdef HAVE_PTHREAD_H
+     if ((libxml_is_threaded)  && (pthread_key_delete != NULL))
+         pthread_key_delete(globalkey);
+-    once_control = PTHREAD_ONCE_INIT;
++    once_control = once_control_init;
+ #elif defined(HAVE_WIN32_THREADS) && !defined(HAVE_COMPILER_TLS) && (!defined(LIBXML_STATIC) || defined(LIBXML_STATIC_FOR_DLL))
+     if (globalkey != TLS_OUT_OF_INDEXES) {
+         xmlGlobalStateCleanupHelperParams *p;

--- a/debian/patches/cve-2013-0338-0339.patch
+++ b/debian/patches/cve-2013-0338-0339.patch
@@ -1,0 +1,148 @@
+From 23f05e0c33987d6605387b300c4be5da2120a7ab Mon Sep 17 00:00:00 2001
+From: Daniel Veillard <veillard@redhat.com>
+Date: Tue, 19 Feb 2013 02:21:49 +0000
+Subject: Detect excessive entities expansion upon replacement
+
+If entities expansion in the XML parser is asked for,
+it is possble to craft relatively small input document leading
+to excessive on-the-fly content generation.
+This patch accounts for those replacement and stop parsing
+after a given threshold. it can be bypassed as usual with the
+HUGE parser option.
+---
+Index: libxml2-2.8.0+dfsg1/include/libxml/parser.h
+===================================================================
+--- libxml2-2.8.0+dfsg1.orig/include/libxml/parser.h	2013-03-06 15:25:52.856052514 -0500
++++ libxml2-2.8.0+dfsg1/include/libxml/parser.h	2013-03-06 15:25:52.840052514 -0500
+@@ -310,6 +310,7 @@
+     xmlParserNodeInfo *nodeInfoTab;   /* array of nodeInfos */
+ 
+     int                input_id;      /* we need to label inputs */
++    unsigned long      sizeentcopy;   /* volume of entity copy */
+ };
+ 
+ /**
+Index: libxml2-2.8.0+dfsg1/parser.c
+===================================================================
+--- libxml2-2.8.0+dfsg1.orig/parser.c	2013-03-06 15:25:52.856052514 -0500
++++ libxml2-2.8.0+dfsg1/parser.c	2013-03-06 15:25:52.848052514 -0500
+@@ -119,7 +119,7 @@
+  */
+ static int
+ xmlParserEntityCheck(xmlParserCtxtPtr ctxt, size_t size,
+-                     xmlEntityPtr ent)
++                     xmlEntityPtr ent, size_t replacement)
+ {
+     size_t consumed = 0;
+ 
+@@ -127,7 +127,24 @@
+         return (0);
+     if (ctxt->lastError.code == XML_ERR_ENTITY_LOOP)
+         return (1);
+-    if (size != 0) {
++    if (replacement != 0) {
++	if (replacement < XML_MAX_TEXT_LENGTH)
++	    return(0);
++
++        /*
++	 * If the volume of entity copy reaches 10 times the
++	 * amount of parsed data and over the large text threshold
++	 * then that's very likely to be an abuse.
++	 */
++        if (ctxt->input != NULL) {
++	    consumed = ctxt->input->consumed +
++	               (ctxt->input->cur - ctxt->input->base);
++	}
++        consumed += ctxt->sizeentities;
++
++        if (replacement < XML_PARSER_NON_LINEAR * consumed)
++	    return(0);
++    } else if (size != 0) {
+         /*
+          * Do the check based on the replacement size of the entity
+          */
+@@ -173,7 +190,6 @@
+          */
+         return (0);
+     }
+-
+     xmlFatalErr(ctxt, XML_ERR_ENTITY_LOOP, NULL);
+     return (1);
+ }
+@@ -2706,7 +2722,7 @@
+ 		    while (*current != 0) { /* non input consuming loop */
+ 			buffer[nbchars++] = *current++;
+ 			if (nbchars + XML_PARSER_BUFFER_SIZE > buffer_size) {
+-			    if (xmlParserEntityCheck(ctxt, nbchars, ent))
++			    if (xmlParserEntityCheck(ctxt, nbchars, ent, 0))
+ 				goto int_error;
+ 			    growBuffer(buffer, XML_PARSER_BUFFER_SIZE);
+ 			}
+@@ -2748,7 +2764,7 @@
+ 		    while (*current != 0) { /* non input consuming loop */
+ 			buffer[nbchars++] = *current++;
+ 			if (nbchars + XML_PARSER_BUFFER_SIZE > buffer_size) {
+-			    if (xmlParserEntityCheck(ctxt, nbchars, ent))
++			    if (xmlParserEntityCheck(ctxt, nbchars, ent, 0))
+ 			        goto int_error;
+ 			    growBuffer(buffer, XML_PARSER_BUFFER_SIZE);
+ 			}
+@@ -6976,7 +6992,7 @@
+ 	    xmlFreeNodeList(list);
+ 	    return;
+ 	}
+-	if (xmlParserEntityCheck(ctxt, 0, ent)) {
++	if (xmlParserEntityCheck(ctxt, 0, ent, 0)) {
+ 	    xmlFreeNodeList(list);
+ 	    return;
+ 	}
+@@ -7136,6 +7152,13 @@
+ 		xmlNodePtr nw = NULL, cur, firstChild = NULL;
+ 
+ 		/*
++		 * We are copying here, make sure there is no abuse
++		 */
++		ctxt->sizeentcopy += ent->length;
++		if (xmlParserEntityCheck(ctxt, 0, ent, ctxt->sizeentcopy))
++		    return;
++
++		/*
+ 		 * when operating on a reader, the entities definitions
+ 		 * are always owning the entities subtree.
+ 		if (ctxt->parseMode == XML_PARSE_READER)
+@@ -7175,6 +7198,14 @@
+ 	    } else if (list == NULL) {
+ 		xmlNodePtr nw = NULL, cur, next, last,
+ 			   firstChild = NULL;
++
++		/*
++		 * We are copying here, make sure there is no abuse
++		 */
++		ctxt->sizeentcopy += ent->length;
++		if (xmlParserEntityCheck(ctxt, 0, ent, ctxt->sizeentcopy))
++		    return;
++
+ 		/*
+ 		 * Copy the entity child list and make it the new
+ 		 * entity child list. The goal is to make sure any
+@@ -14355,6 +14386,7 @@
+     ctxt->catalogs = NULL;
+     ctxt->nbentities = 0;
+     ctxt->sizeentities = 0;
++    ctxt->sizeentcopy = 0;
+     xmlInitNodeInfoSeq(&ctxt->node_seq);
+ 
+     if (ctxt->attsDefault != NULL) {
+Index: libxml2-2.8.0+dfsg1/parserInternals.c
+===================================================================
+--- libxml2-2.8.0+dfsg1.orig/parserInternals.c	2013-03-06 15:25:52.856052514 -0500
++++ libxml2-2.8.0+dfsg1/parserInternals.c	2013-03-06 15:25:52.848052514 -0500
+@@ -1761,6 +1761,8 @@
+     ctxt->charset = XML_CHAR_ENCODING_UTF8;
+     ctxt->catalogs = NULL;
+     ctxt->nbentities = 0;
++    ctxt->sizeentities = 0;
++    ctxt->sizeentcopy = 0;
+     ctxt->input_id = 1;
+     xmlInitNodeInfoSeq(&ctxt->node_seq);
+     return(0);

--- a/debian/patches/cve-2013-2877.patch
+++ b/debian/patches/cve-2013-2877.patch
@@ -1,0 +1,472 @@
+From 48b4cdde3483e054af8ea02e0cd7ee467b0e9a50 Mon Sep 17 00:00:00 2001
+From: Daniel Veillard <veillard@redhat.com>
+Date: Mon, 30 Jul 2012 08:16:04 +0000
+Subject: Enforce XML_PARSER_EOF state handling through the parser
+
+That condition is one raised when the parser should positively stop
+processing further even to report errors. Best is to test is after
+most GROW call especially within loops
+---
+Index: libxml2-2.8.0+dfsg1/parser.c
+===================================================================
+--- libxml2-2.8.0+dfsg1.orig/parser.c	2013-10-13 05:00:55.000000000 +0000
++++ libxml2-2.8.0+dfsg1/parser.c	2013-10-13 05:23:59.382749936 +0000
+@@ -2161,6 +2161,8 @@
+ 		"Pushing input %d : %.30s\n", ctxt->inputNr+1, input->cur);
+     }
+     ret = inputPush(ctxt, input);
++    if (ctxt->instate == XML_PARSER_EOF)
++        return(-1);
+     GROW;
+     return(ret);
+ }
+@@ -2197,6 +2199,8 @@
+ 	    if (count++ > 20) {
+ 		count = 0;
+ 		GROW;
++                if (ctxt->instate == XML_PARSER_EOF)
++                    return(0);
+ 	    }
+ 	    if ((RAW >= '0') && (RAW <= '9')) 
+ 	        val = val * 16 + (CUR - '0');
+@@ -2228,6 +2232,8 @@
+ 	    if (count++ > 20) {
+ 		count = 0;
+ 		GROW;
++                if (ctxt->instate == XML_PARSER_EOF)
++                    return(0);
+ 	    }
+ 	    if ((RAW >= '0') && (RAW <= '9')) 
+ 	        val = val * 10 + (CUR - '0');
+@@ -2576,6 +2582,8 @@
+ 		     * the amount of data in the buffer.
+ 		     */
+ 		    GROW
++                    if (ctxt->instate == XML_PARSER_EOF)
++                        return;
+ 		    if ((ctxt->input->end - ctxt->input->cur)>=4) {
+ 			start[0] = RAW;
+ 			start[1] = NXT(1);
+@@ -3194,6 +3202,8 @@
+      * Handler for more complex cases
+      */
+     GROW;
++    if (ctxt->instate == XML_PARSER_EOF)
++        return(NULL);
+     c = CUR_CHAR(l);
+     if ((ctxt->options & XML_PARSE_OLD10) == 0) {
+         /*
+@@ -3245,6 +3255,8 @@
+ 	    if (count++ > 100) {
+ 		count = 0;
+ 		GROW;
++                if (ctxt->instate == XML_PARSER_EOF)
++                    return(NULL);
+ 	    }
+ 	    len += l;
+ 	    NEXTL(l);
+@@ -3269,6 +3281,8 @@
+ 	    if (count++ > 100) {
+ 		count = 0;
+ 		GROW;
++                if (ctxt->instate == XML_PARSER_EOF)
++                    return(NULL);
+ 	    }
+ 	    len += l;
+ 	    NEXTL(l);
+@@ -3362,6 +3376,8 @@
+ 	if (count++ > 100) {
+ 	    count = 0;
+ 	    GROW;
++            if (ctxt->instate == XML_PARSER_EOF)
++                return(NULL);
+ 	}
+ 	len += l;
+ 	NEXTL(l);
+@@ -3442,6 +3458,8 @@
+     const xmlChar *ret;
+ 
+     GROW;
++    if (ctxt->instate == XML_PARSER_EOF)
++        return(NULL);
+ 
+     in = ctxt->input->cur;
+     while (*in != 0 && *in == *cmp) {
+@@ -3569,6 +3587,8 @@
+ #endif
+ 
+     GROW;
++    if (ctxt->instate == XML_PARSER_EOF)
++        return(NULL);
+     c = CUR_CHAR(l);
+ 
+     while (xmlIsNameChar(ctxt, c)) {
+@@ -3597,6 +3617,10 @@
+ 		if (count++ > 100) {
+ 		    count = 0;
+ 		    GROW;
++                    if (ctxt->instate == XML_PARSER_EOF) {
++                        xmlFree(buffer);
++                        return(NULL);
++                    }
+ 		}
+ 		if (len + 10 > max) {
+ 		    xmlChar *tmp;
+@@ -3667,6 +3691,10 @@
+     ctxt->instate = XML_PARSER_ENTITY_VALUE;
+     input = ctxt->input;
+     GROW;
++    if (ctxt->instate == XML_PARSER_EOF) {
++        xmlFree(buf);
++        return(NULL);
++    }
+     NEXT;
+     c = CUR_CHAR(l);
+     /*
+@@ -3678,8 +3706,8 @@
+      * In practice it means we stop the loop only when back at parsing
+      * the initial entity and the quote is found
+      */
+-    while ((IS_CHAR(c)) && ((c != stop) || /* checked */
+-	   (ctxt->input != input))) {
++    while (((IS_CHAR(c)) && ((c != stop) || /* checked */
++	    (ctxt->input != input))) && (ctxt->instate != XML_PARSER_EOF)) {
+ 	if (len + 5 >= size) {
+ 	    xmlChar *tmp;
+ 
+@@ -3708,6 +3736,10 @@
+ 	}
+     }
+     buf[len] = 0;
++    if (ctxt->instate == XML_PARSER_EOF) {
++        xmlFree(buf);
++        return(NULL);
++    }
+ 
+     /*
+      * Raise problem w.r.t. '&' and '%' being used in non-entities
+@@ -3755,12 +3787,12 @@
+ 	 */
+ 	ret = xmlStringDecodeEntities(ctxt, buf, XML_SUBSTITUTE_PEREF,
+ 				      0, 0, 0);
+-	if (orig != NULL) 
++	if (orig != NULL)
+ 	    *orig = buf;
+ 	else
+ 	    xmlFree(buf);
+     }
+-    
++
+     return(ret);
+ }
+ 
+@@ -3811,8 +3843,9 @@
+      * OK loop until we reach one of the ending char or a size limit.
+      */
+     c = CUR_CHAR(l);
+-    while ((NXT(0) != limit) && /* checked */
+-           (IS_CHAR(c)) && (c != '<')) {
++    while (((NXT(0) != limit) && /* checked */
++            (IS_CHAR(c)) && (c != '<')) &&
++            (ctxt->instate != XML_PARSER_EOF)) {
+ 	if (c == 0) break;
+ 	if (c == '&') {
+ 	    in_space = 0;
+@@ -3947,6 +3980,9 @@
+ 	GROW;
+ 	c = CUR_CHAR(l);
+     }
++    if (ctxt->instate == XML_PARSER_EOF)
++        goto error;
++
+     if ((in_space) && (normalize)) {
+         while ((len > 0) && (buf[len - 1] == 0x20)) len--;
+     }
+@@ -3979,6 +4015,7 @@
+ 
+ mem_error:
+     xmlErrMemory(ctxt, NULL);
++error:
+     if (buf != NULL)
+         xmlFree(buf);
+     if (rep != NULL)
+@@ -4084,6 +4121,10 @@
+ 	if (count > 50) {
+ 	    GROW;
+ 	    count = 0;
++            if (ctxt->instate == XML_PARSER_EOF) {
++	        xmlFree(buf);
++		return(NULL);
++            }
+ 	}
+ 	COPY_BUF(l,buf,len,cur);
+ 	NEXTL(l);
+@@ -4161,6 +4202,10 @@
+ 	if (count > 50) {
+ 	    GROW;
+ 	    count = 0;
++            if (ctxt->instate == XML_PARSER_EOF) {
++		xmlFree(buf);
++		return(NULL);
++            }
+ 	}
+ 	NEXT;
+ 	cur = CUR;
+@@ -4367,6 +4412,8 @@
+ 	    }
+ 	    SHRINK;
+ 	    GROW;
++            if (ctxt->instate == XML_PARSER_EOF)
++		return;
+ 	    in = ctxt->input->cur;
+ 	} while (((*in >= 0x20) && (*in <= 0x7F)) || (*in == 0x09));
+ 	nbchar = 0;
+@@ -4435,6 +4482,8 @@
+ 	if (count > 50) {
+ 	    GROW;
+ 	    count = 0;
++            if (ctxt->instate == XML_PARSER_EOF)
++		return;
+ 	}
+ 	NEXTL(l);
+ 	cur = CUR_CHAR(l);
+@@ -4635,6 +4684,10 @@
+ 	if (count > 50) {
+ 	    GROW;
+ 	    count = 0;
++            if (ctxt->instate == XML_PARSER_EOF) {
++		xmlFree(buf);
++		return;
++            }
+ 	}
+ 	NEXTL(l);
+ 	cur = CUR_CHAR(l);
+@@ -4785,6 +4838,10 @@
+ 	}
+ 	SHRINK;
+ 	GROW;
++        if (ctxt->instate == XML_PARSER_EOF) {
++            xmlFree(buf);
++            return;
++        }
+ 	in = ctxt->input->cur;
+ 	if (*in == '-') {
+ 	    if (in[1] == '-') {
+@@ -5022,6 +5079,10 @@
+ 		count++;
+ 		if (count > 50) {
+ 		    GROW;
++                    if (ctxt->instate == XML_PARSER_EOF) {
++                        xmlFree(buf);
++                        return;
++                    }
+ 		    count = 0;
+ 		}
+ 		COPY_BUF(l,buf,len,cur);
+@@ -5762,7 +5823,7 @@
+ 	}
+ 	SKIP_BLANKS;
+ 	GROW;
+-	while (RAW != '>') {
++	while ((RAW != '>') && (ctxt->instate != XML_PARSER_EOF)) {
+ 	    const xmlChar *check = CUR_PTR;
+ 	    int type;
+ 	    int def;
+@@ -5911,7 +5972,7 @@
+ 	    ret = cur = xmlNewDocElementContent(ctxt->myDoc, NULL, XML_ELEMENT_CONTENT_PCDATA);
+ 	    if (ret == NULL) return(NULL);
+ 	}
+-	while (RAW == '|') {
++	while ((RAW == '|') && (ctxt->instate != XML_PARSER_EOF)) {
+ 	    NEXT;
+ 	    if (elem == NULL) {
+ 	        ret = xmlNewDocElementContent(ctxt->myDoc, NULL, XML_ELEMENT_CONTENT_OR);
+@@ -6055,7 +6116,7 @@
+     }
+     SKIP_BLANKS;
+     SHRINK;
+-    while (RAW != ')') {
++    while ((RAW != ')') && (ctxt->instate != XML_PARSER_EOF)) {
+         /*
+ 	 * Each loop we parse one separator and one element.
+ 	 */
+@@ -6334,6 +6395,8 @@
+     }
+     NEXT;
+     GROW;
++    if (ctxt->instate == XML_PARSER_EOF)
++        return(-1);
+     SKIP_BLANKS;
+     if (CMP7(CUR_PTR, '#', 'P', 'C', 'D', 'A', 'T', 'A')) {
+         tree = xmlParseElementMixedContentDecl(ctxt, inputid);
+@@ -6501,8 +6564,8 @@
+ 		    "Entering INCLUDE Conditional Section\n");
+ 	}
+ 
+-	while ((RAW != 0) && ((RAW != ']') || (NXT(1) != ']') ||
+-	       (NXT(2) != '>'))) {
++	while (((RAW != 0) && ((RAW != ']') || (NXT(1) != ']') ||
++	        (NXT(2) != '>'))) && (ctxt->instate != XML_PARSER_EOF)) {
+ 	    const xmlChar *check = CUR_PTR;
+ 	    unsigned int cons = ctxt->input->consumed;
+ 
+@@ -6570,7 +6633,8 @@
+ 	if (ctxt->recovery == 0) ctxt->disableSAX = 1;
+ 	ctxt->instate = XML_PARSER_IGNORE;
+ 
+-	while ((depth >= 0) && (RAW != 0)) {
++	while (((depth >= 0) && (RAW != 0)) &&
++               (ctxt->instate != XML_PARSER_EOF)) {
+ 	  if ((RAW == '<') && (NXT(1) == '!') && (NXT(2) == '[')) {
+ 	    depth++;
+ 	    SKIP(3);
+@@ -6841,7 +6905,7 @@
+ 	    break;
+ 	}
+     }
+-    
++
+     if (RAW != 0) {
+ 	xmlFatalErr(ctxt, XML_ERR_EXT_SUBSET_NOT_FINISHED, NULL);
+     }
+@@ -7303,6 +7367,8 @@
+     xmlEntityPtr ent = NULL;
+ 
+     GROW;
++    if (ctxt->instate == XML_PARSER_EOF)
++        return(NULL);
+ 
+     if (RAW != '&')
+         return(NULL);
+@@ -7833,6 +7899,10 @@
+ 	if (count++ > 100) {
+ 	    count = 0;
+ 	    GROW;
++            if (ctxt->instate == XML_PARSER_EOF) {
++                xmlBufferFree(buf);
++                return(-1);
++            }
+ 	}
+ 	NEXTL(l);
+ 	c = CUR_CHAR(l);
+@@ -8066,7 +8136,7 @@
+ 	 * PEReferences.
+ 	 * Subsequence (markupdecl | PEReference | S)*
+ 	 */
+-	while (RAW != ']') {
++	while ((RAW != ']') && (ctxt->instate != XML_PARSER_EOF)) {
+ 	    const xmlChar *check = CUR_PTR;
+ 	    unsigned int cons = ctxt->input->consumed;
+ 
+@@ -8252,9 +8322,9 @@
+     SKIP_BLANKS;
+     GROW;
+ 
+-    while ((RAW != '>') && 
++    while (((RAW != '>') && 
+ 	   ((RAW != '/') || (NXT(1) != '>')) &&
+-	   (IS_BYTE_CHAR(RAW))) {
++	   (IS_BYTE_CHAR(RAW))) && (ctxt->instate != XML_PARSER_EOF)) {
+ 	const xmlChar *q = CUR_PTR;
+ 	unsigned int cons = ctxt->input->consumed;
+ 
+@@ -8678,6 +8748,8 @@
+ 	    if (in >= end) {
+ 		const xmlChar *oldbase = ctxt->input->base;
+ 		GROW;
++                if (ctxt->instate == XML_PARSER_EOF)
++                    return(NULL);
+ 		if (oldbase != ctxt->input->base) {
+ 		    long delta = ctxt->input->base - oldbase;
+ 		    start = start + delta;
+@@ -8692,6 +8764,8 @@
+ 	    if (in >= end) {
+ 		const xmlChar *oldbase = ctxt->input->base;
+ 		GROW;
++                if (ctxt->instate == XML_PARSER_EOF)
++                    return(NULL);
+ 		if (oldbase != ctxt->input->base) {
+ 		    long delta = ctxt->input->base - oldbase;
+ 		    start = start + delta;
+@@ -8712,6 +8786,8 @@
+ 	    if (in >= end) {
+ 		const xmlChar *oldbase = ctxt->input->base;
+ 		GROW;
++                if (ctxt->instate == XML_PARSER_EOF)
++                    return(NULL);
+ 		if (oldbase != ctxt->input->base) {
+ 		    long delta = ctxt->input->base - oldbase;
+ 		    start = start + delta;
+@@ -8729,6 +8805,8 @@
+ 	    if (in >= end) {
+ 		const xmlChar *oldbase = ctxt->input->base;
+ 		GROW;
++                if (ctxt->instate == XML_PARSER_EOF)
++                    return(NULL);
+ 		if (oldbase != ctxt->input->base) {
+ 		    long delta = ctxt->input->base - oldbase;
+ 		    start = start + delta;
+@@ -8960,9 +9038,9 @@
+     GROW;
+     if (ctxt->input->base != base) goto base_changed;
+ 
+-    while ((RAW != '>') && 
++    while (((RAW != '>') &&
+ 	   ((RAW != '/') || (NXT(1) != '>')) &&
+-	   (IS_BYTE_CHAR(RAW))) {
++	   (IS_BYTE_CHAR(RAW))) && (ctxt->instate != XML_PARSER_EOF)) {
+ 	const xmlChar *q = CUR_PTR;
+ 	unsigned int cons = ctxt->input->consumed;
+ 	int len = -1, alloc = 0;
+@@ -9133,6 +9211,8 @@
+ failed:
+ 
+ 	GROW
++        if (ctxt->instate == XML_PARSER_EOF)
++            break;
+ 	if (ctxt->input->base != base) goto base_changed;
+ 	if ((RAW == '>') || (((RAW == '/') && (NXT(1) == '>'))))
+ 	    break;
+@@ -9370,6 +9450,8 @@
+      * We should definitely be at the ending "S? '>'" part
+      */
+     GROW;
++    if (ctxt->instate == XML_PARSER_EOF)
++        return;
+     SKIP_BLANKS;
+     if ((!IS_BYTE_CHAR(RAW)) || (RAW != '>')) {
+ 	xmlFatalErr(ctxt, XML_ERR_GT_REQUIRED, NULL);
+@@ -9478,6 +9560,10 @@
+ 	count++;
+ 	if (count > 50) {
+ 	    GROW;
++            if (ctxt->instate == XML_PARSER_EOF) {
++		xmlFree(buf);
++		return;
++            }
+ 	    count = 0;
+ 	}
+ 	NEXTL(l);
+@@ -10248,9 +10334,10 @@
+ 
+ void
+ xmlParseMisc(xmlParserCtxtPtr ctxt) {
+-    while (((RAW == '<') && (NXT(1) == '?')) ||
+-           (CMP4(CUR_PTR, '<', '!', '-', '-')) ||
+-           IS_BLANK_CH(CUR)) {
++    while ((ctxt->instate != XML_PARSER_EOF) &&
++           (((RAW == '<') && (NXT(1) == '?')) ||
++            (CMP4(CUR_PTR, '<', '!', '-', '-')) ||
++            IS_BLANK_CH(CUR))) {
+         if ((RAW == '<') && (NXT(1) == '?')) {
+ 	    xmlParsePI(ctxt);
+ 	} else if (IS_BLANK_CH(CUR)) {
+@@ -11720,6 +11807,8 @@
+         return(XML_ERR_INTERNAL_ERROR);
+     if ((ctxt->errNo != XML_ERR_OK) && (ctxt->disableSAX == 1))
+         return(ctxt->errNo);
++    if (ctxt->instate == XML_PARSER_EOF)
++        return(-1);
+     if (ctxt->instate == XML_PARSER_START)
+         xmlDetectSAX2(ctxt);
+     if ((size > 0) && (chunk != NULL) && (!terminate) &&

--- a/debian/patches/cve-2014-0191.patch
+++ b/debian/patches/cve-2014-0191.patch
@@ -1,0 +1,56 @@
+From: Aron Xu <aron@debian.org>
+Date: Sun, 26 Oct 2014 12:24:03 +0800
+Subject: cve-2014-0191
+
+---
+ parser.c |   23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/parser.c b/parser.c
+index 57500ef..7ef712d 100644
+--- a/parser.c
++++ b/parser.c
+@@ -2564,6 +2564,23 @@ xmlParserHandlePEReference(xmlParserCtxtPtr ctxt) {
+ 		    xmlCharEncoding enc;
+ 
+ 		    /*
++		     * Note: external parameter entities will not be loaded, it
++		     * is not required for a non-validating parser, unless the
++		     * option of validating, or substituting entities were
++		     * given. Doing so is far more secure as the parser will
++		     * only process data coming from the document entity by
++		     * default.
++		     */
++                    if ((entity->etype == XML_EXTERNAL_PARAMETER_ENTITY) &&
++		        ((ctxt->options & XML_PARSE_NOENT) == 0) &&
++			((ctxt->options & XML_PARSE_DTDVALID) == 0) &&
++			((ctxt->options & XML_PARSE_DTDLOAD) == 0) &&
++			((ctxt->options & XML_PARSE_DTDATTR) == 0) &&
++			(ctxt->replaceEntities == 0) &&
++			(ctxt->validate == 0))
++			return;
++
++		    /*
+ 		     * handle the extra spaces added before and after
+ 		     * c.f. http://www.w3.org/TR/REC-xml#as-PE
+ 		     * this is done independently.
+@@ -12197,6 +12214,9 @@ xmlIOParseDTD(xmlSAXHandlerPtr sax, xmlParserInputBufferPtr input,
+ 	return(NULL);
+     }
+ 
++    /* We are loading a DTD */
++    ctxt->options |= XML_PARSE_DTDLOAD;
++
+     /*
+      * Set-up the SAX context
+      */
+@@ -12324,6 +12344,9 @@ xmlSAXParseDTD(xmlSAXHandlerPtr sax, const xmlChar *ExternalID,
+ 	return(NULL);
+     }
+ 
++    /* We are loading a DTD */
++    ctxt->options |= XML_PARSE_DTDLOAD;
++
+     /*
+      * Set-up the SAX context
+      */

--- a/debian/patches/cve-2014-3660.patch
+++ b/debian/patches/cve-2014-3660.patch
@@ -1,0 +1,139 @@
+From: Daniel Veillard <veillard@redhat.com>
+Date: Sun, 26 Oct 2014 12:35:43 +0800
+Subject: Fix for CVE-2014-3660
+
+---
+ parser.c |   42 ++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 38 insertions(+), 4 deletions(-)
+
+diff --git a/parser.c b/parser.c
+index 7ef712d..b435913 100644
+--- a/parser.c
++++ b/parser.c
+@@ -127,6 +127,29 @@ xmlParserEntityCheck(xmlParserCtxtPtr ctxt, size_t size,
+         return (0);
+     if (ctxt->lastError.code == XML_ERR_ENTITY_LOOP)
+         return (1);
++
++    /*
++     * This may look absurd but is needed to detect
++     * entities problems
++     */
++    if ((ent != NULL) && (ent->etype != XML_INTERNAL_PREDEFINED_ENTITY) &&
++	(ent->content != NULL) && (ent->checked == 0)) {
++	unsigned long oldnbent = ctxt->nbentities;
++	xmlChar *rep;
++
++	ent->checked = 1;
++
++	rep = xmlStringDecodeEntities(ctxt, ent->content,
++				  XML_SUBSTITUTE_REF, 0, 0, 0);
++
++	ent->checked = (ctxt->nbentities - oldnbent + 1) * 2;
++	if (rep != NULL) {
++	    if (xmlStrchr(rep, '<'))
++		ent->checked |= 1;
++	    xmlFree(rep);
++	    rep = NULL;
++	}
++    }
+     if (replacement != 0) {
+ 	if (replacement < XML_MAX_TEXT_LENGTH)
+ 	    return(0);
+@@ -186,9 +209,12 @@ xmlParserEntityCheck(xmlParserCtxtPtr ctxt, size_t size,
+             return (0);
+     } else {
+         /*
+-         * strange we got no data for checking just return
++         * strange we got no data for checking
+          */
+-        return (0);
++	if (((ctxt->lastError.code != XML_ERR_UNDECLARED_ENTITY) &&
++	     (ctxt->lastError.code != XML_WAR_UNDECLARED_ENTITY)) ||
++	    (ctxt->nbentities <= 10000))
++	    return (0);
+     }
+     xmlFatalErr(ctxt, XML_ERR_ENTITY_LOOP, NULL);
+     return (1);
+@@ -2553,6 +2579,7 @@ xmlParserHandlePEReference(xmlParserCtxtPtr ctxt) {
+ 				      name, NULL);
+ 		    ctxt->valid = 0;
+ 		}
++		xmlParserEntityCheck(ctxt, 0, NULL, 0);
+ 	    } else if (ctxt->input->free != deallocblankswrapper) {
+ 		    input = xmlNewBlanksWrapperInputStream(ctxt, entity);
+ 		    if (xmlPushInput(ctxt, input) < 0)
+@@ -2723,6 +2750,7 @@ xmlStringLenDecodeEntities(xmlParserCtxtPtr ctxt, const xmlChar *str, int len,
+ 	    if ((ctxt->lastError.code == XML_ERR_ENTITY_LOOP) ||
+ 	        (ctxt->lastError.code == XML_ERR_INTERNAL_ERROR))
+ 	        goto int_error;
++	    xmlParserEntityCheck(ctxt, 0, ent, 0);
+ 	    if (ent != NULL)
+ 	        ctxt->nbentities += ent->checked;
+ 	    if ((ent != NULL) &&
+@@ -2774,6 +2802,7 @@ xmlStringLenDecodeEntities(xmlParserCtxtPtr ctxt, const xmlChar *str, int len,
+ 	    ent = xmlParseStringPEReference(ctxt, &str);
+ 	    if (ctxt->lastError.code == XML_ERR_ENTITY_LOOP)
+ 	        goto int_error;
++	    xmlParserEntityCheck(ctxt, 0, ent, 0);
+ 	    if (ent != NULL)
+ 	        ctxt->nbentities += ent->checked;
+ 	    if (ent != NULL) {
+@@ -7127,6 +7156,7 @@ xmlParseReference(xmlParserCtxtPtr ctxt) {
+ 		   (ret != XML_WAR_UNDECLARED_ENTITY)) {
+ 	    xmlFatalErrMsgStr(ctxt, XML_ERR_UNDECLARED_ENTITY,
+ 		     "Entity '%s' failed to parse\n", ent->name);
++	    xmlParserEntityCheck(ctxt, 0, ent, 0);
+ 	} else if (list != NULL) {
+ 	    xmlFreeNodeList(list);
+ 	    list = NULL;
+@@ -7235,7 +7265,7 @@ xmlParseReference(xmlParserCtxtPtr ctxt) {
+ 		/*
+ 		 * We are copying here, make sure there is no abuse
+ 		 */
+-		ctxt->sizeentcopy += ent->length;
++		ctxt->sizeentcopy += ent->length + 5;
+ 		if (xmlParserEntityCheck(ctxt, 0, ent, ctxt->sizeentcopy))
+ 		    return;
+ 
+@@ -7283,7 +7313,7 @@ xmlParseReference(xmlParserCtxtPtr ctxt) {
+ 		/*
+ 		 * We are copying here, make sure there is no abuse
+ 		 */
+-		ctxt->sizeentcopy += ent->length;
++		ctxt->sizeentcopy += ent->length + 5;
+ 		if (xmlParserEntityCheck(ctxt, 0, ent, ctxt->sizeentcopy))
+ 		    return;
+ 
+@@ -7467,6 +7497,7 @@ xmlParseEntityRef(xmlParserCtxtPtr ctxt) {
+ 		ctxt->sax->reference(ctxt->userData, name);
+ 	    }
+ 	}
++	xmlParserEntityCheck(ctxt, 0, ent, 0);
+ 	ctxt->valid = 0;
+     }
+ 
+@@ -7654,6 +7685,7 @@ xmlParseStringEntityRef(xmlParserCtxtPtr ctxt, const xmlChar ** str) {
+ 			  "Entity '%s' not defined\n",
+ 			  name);
+ 	}
++	xmlParserEntityCheck(ctxt, 0, ent, 0);
+ 	/* TODO ? check regressions ctxt->valid = 0; */
+     }
+ 
+@@ -7812,6 +7844,7 @@ xmlParsePEReference(xmlParserCtxtPtr ctxt)
+ 			  name, NULL);
+ 	    ctxt->valid = 0;
+ 	}
++	xmlParserEntityCheck(ctxt, 0, NULL, 0);
+     } else {
+ 	/*
+ 	 * Internal checking in case the entity quest barfed
+@@ -8039,6 +8072,7 @@ xmlParseStringPEReference(xmlParserCtxtPtr ctxt, const xmlChar **str) {
+ 			  name, NULL);
+ 	    ctxt->valid = 0;
+ 	}
++	xmlParserEntityCheck(ctxt, 0, NULL, 0);
+     } else {
+ 	/*
+ 	 * Internal checking in case the entity quest barfed

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,6 +4,8 @@
 0004-Fix-entities-local-buffers-size-problems.patch
 0005-Fix-a-failure-to-report-xmlreader-parsing-failures.patch
 0006-Fix-potential-out-of-bound-access.patch
+0007-Fix-pthread-memory-corruption.patch
+0008-Fix-a-thread-portability-problem.patch
 cve-2013-0338-0339.patch
 cve-2013-2877.patch
 0200-Fix-case-statement.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,4 +4,5 @@
 0004-Fix-entities-local-buffers-size-problems.patch
 0005-Fix-a-failure-to-report-xmlreader-parsing-failures.patch
 0006-Fix-potential-out-of-bound-access.patch
+cve-2013-0338-0339.patch
 0200-Fix-case-statement.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,4 +8,5 @@
 0008-Fix-a-thread-portability-problem.patch
 cve-2013-0338-0339.patch
 cve-2013-2877.patch
+cve-2014-0191.patch
 0200-Fix-case-statement.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,4 +5,5 @@
 0005-Fix-a-failure-to-report-xmlreader-parsing-failures.patch
 0006-Fix-potential-out-of-bound-access.patch
 cve-2013-0338-0339.patch
+cve-2013-2877.patch
 0200-Fix-case-statement.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,4 +9,5 @@
 cve-2013-0338-0339.patch
 cve-2013-2877.patch
 cve-2014-0191.patch
+cve-2014-3660.patch
 0200-Fix-case-statement.patch

--- a/include/libxml/xmlversion.h
+++ b/include/libxml/xmlversion.h
@@ -29,28 +29,28 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.6.32"
+#define LIBXML_DOTTED_VERSION "2.8.0"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 20632
+#define LIBXML_VERSION 20800
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "20632"
+#define LIBXML_VERSION_STRING "20800"
 
 /**
  * LIBXML_VERSION_EXTRA:
  *
  * extra version information, used to show a CVS compilation
  */
-#define LIBXML_VERSION_EXTRA "-CVS2831"
+#define LIBXML_VERSION_EXTRA "-GITv2.8.0-rc2-1-g22030ef"
 
 /**
  * LIBXML_TEST_VERSION:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(20632);
+#define LIBXML_TEST_VERSION xmlCheckVersion(20800);
 
 #ifndef VMS
 #if 0
@@ -269,6 +269,15 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
 #endif
 
 /**
+ * LIBXML_ICU_ENABLED:
+ *
+ * Whether icu support is available
+ */
+#if 0
+#define LIBXML_ICU_ENABLED
+#endif
+
+/**
  * LIBXML_ISO8859X_ENABLED:
  *
  * Whether ISO-8859-* support is made available in case iconv is not
@@ -291,7 +300,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * Whether the memory debugging is configured in
  */
-#if 1
+#if 0
 #define DEBUG_MEMORY_LOCATION
 #endif
 
@@ -300,7 +309,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * Whether the runtime debugging is configured in
  */
-#if 1
+#if 0
 #define LIBXML_DEBUG_RUNTIME
 #endif
 
@@ -383,20 +392,81 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
 #endif
 
 /**
- * ATTRIBUTE_UNUSED:
+ * LIBXML_LZMA_ENABLED:
  *
- * Macro used to signal to GCC unused function parameters
+ * Whether the Lzma support is compiled in
  */
+#if 1
+#define LIBXML_LZMA_ENABLED
+#endif
+
 #ifdef __GNUC__
 #ifdef HAVE_ANSIDECL_H
 #include <ansidecl.h>
 #endif
+
+/**
+ * ATTRIBUTE_UNUSED:
+ *
+ * Macro used to signal to GCC unused function parameters
+ */
+
 #ifndef ATTRIBUTE_UNUSED
 #define ATTRIBUTE_UNUSED __attribute__((unused))
 #endif
+
+/**
+ * LIBXML_ATTR_ALLOC_SIZE:
+ *
+ * Macro used to indicate to GCC this is an allocator function
+ */
+
+#ifndef LIBXML_ATTR_ALLOC_SIZE
+# if ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 3)))
+#  define LIBXML_ATTR_ALLOC_SIZE(x) __attribute__((alloc_size(x)))
+# else
+#  define LIBXML_ATTR_ALLOC_SIZE(x)
+# endif
 #else
-#define ATTRIBUTE_UNUSED
+# define LIBXML_ATTR_ALLOC_SIZE(x)
 #endif
+
+/**
+ * LIBXML_ATTR_FORMAT:
+ *
+ * Macro used to indicate to GCC the parameter are printf like
+ */
+
+#ifndef LIBXML_ATTR_FORMAT
+# if ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)))
+#  define LIBXML_ATTR_FORMAT(fmt,args) __attribute__((__format__(__printf__,fmt,args)))
+# else
+#  define LIBXML_ATTR_FORMAT(fmt,args)
+# endif
+#else
+# define LIBXML_ATTR_FORMAT(fmt,args)
+#endif
+
+#else /* ! __GNUC__ */
+/**
+ * ATTRIBUTE_UNUSED:
+ *
+ * Macro used to signal to GCC unused function parameters
+ */
+#define ATTRIBUTE_UNUSED
+/**
+ * LIBXML_ATTR_ALLOC_SIZE:
+ *
+ * Macro used to indicate to GCC this is an allocator function
+ */
+#define LIBXML_ATTR_ALLOC_SIZE(x)
+/**
+ * LIBXML_ATTR_FORMAT:
+ *
+ * Macro used to indicate to GCC the parameter are printf like
+ */
+#define LIBXML_ATTR_FORMAT(fmt,args)
+#endif /* __GNUC__ */
 
 #ifdef __cplusplus
 }

--- a/python/setup.py
+++ b/python/setup.py
@@ -226,7 +226,7 @@ else:
 setup (name = "libxml2-python",
        # On *nix, the version number is created from setup.py.in
        # On windows, it is set by configure.js
-       version = "2.6.32",
+       version = "2.8.0",
        description = descr,
        author = "Daniel Veillard",
        author_email = "veillard@redhat.com",


### PR DESCRIPTION
- Fix cve-2013-0338 and cve-2013-0339: large memory consuption issues when
  performing string substition during entity expansion (closes: #702260).
- Fix cve-2013-2877: out-of-bounds read when handling documents that end
  abruptly.
- 0007-Fix-pthread-memory-corruption.patch: patch stolen from the 
  upstream repository. Fix memory corruption when re-using the libxml2 
  from threaded applications (Closes: #742258).
- 0008-Fix-a-thread-portability-problem.patch: Fix buggy patch 0007
  (Closes: #765770)
- debian/patches/cve-2014-0191.patch: libxml2 could be made to consume
  resources if it processed a specially crafted file.
  (Closes: #747309, #762864, CVE-2014-0191)
- Add patch for CVE-2014-3660 (Closes: #765722)
